### PR TITLE
Fix: rate expression validation

### DIFF
--- a/src/serverless.js
+++ b/src/serverless.js
@@ -13,7 +13,7 @@ class LambdaCron extends Component {
         "Input 'schedule' is required. Please see README: https://git.io/JJWW0"
       );
     }
-    const { schedule } = inputs.schedule;
+    const { schedule } = inputs;
 
     let valid = false;
 
@@ -24,7 +24,7 @@ class LambdaCron extends Component {
     }
 
     // Check for a rate expression
-    const rateRegex = /rate(\d+\s+(minute|minutes|hour|hours|day|days))/;
+    const rateRegex = /rate\(\d+\s+(minute|minutes|hour|hours|day|days)\)/;
     if (rateRegex.test(schedule)) {
       valid = true;
     }


### PR DESCRIPTION
Hi, I pulled the master branch and published the component as `@dev`.

No matter what string I enter into the schedule property, I encounter the following error:

```
serverless deploy --debug
Initializing...
Action: "deploy" - Stage: "dev" - Org: "zenstyle" - App: "aws-lambda-cron-template" - Name: "aws-lambda-cron-template"
Deploying...

 Error: Schedule expression is invalid. Please recheck it.
    at LambdaCron.validate (/var/task/serverless.js:35:13)
    at LambdaCron.deploy (/var/task/serverless.js:45:10)
    at Runtime.module.exports [as handler] (/opt/nodejs/node_modules/@serverless/core/handler.js:337:53)
7s › Serverless › Schedule expression is invalid. Please recheck it. 

  Documentation: https://github.com/serverless/components 
  Support: https://app.serverless.com/support 
  Slack: https://www.serverless.com/slack/ 
```

Isn't the problem with input value substitution and regular expressions?